### PR TITLE
Fix slider tooltip to show timestamp when dragging

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -17,7 +17,7 @@ interface ISliderProps {
     gaps: { start: number; end: number }[];
     dataByGapsPositions: { start: number; end: number }[];
     valueToPosition: (value: number) => number;
-    positionToValue: (value: number) => number;
+    positionToValue: (position: number) => number;
   };
   disabled?: boolean;
 }
@@ -49,7 +49,6 @@ export const Slider = ({
       e.preventDefault();
 
       setIsDragging(true);
-      setShowTooltip(true);
 
       const updatePosition = (clientX: number) => {
         if (!sliderRef.current) return;
@@ -70,12 +69,6 @@ export const Slider = ({
   );
 
   useEffect(() => {
-    if (isDragging) {
-      setShowTooltip(true);
-    } else {
-      setShowTooltip(false);
-    }
-
     if (!isDragging) return;
 
     const handleMouseMove = (e: MouseEvent | TouchEvent) => {
@@ -91,7 +84,6 @@ export const Slider = ({
 
     const handleMouseUp = () => {
       setIsDragging(false);
-      setShowTooltip(false);
     };
 
     document.addEventListener("mousemove", handleMouseMove);
@@ -120,7 +112,7 @@ export const Slider = ({
       className="ml-[20px] rounded-md bg-[#3399FF] px-2 py-1.5 text-center text-xs text-white"
       align="start"
       sideOffset={12}
-      disabled={!showTooltip}
+      disabled={!showTooltip && !isDragging}
     >
       <div
         ref={sliderRef}

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -17,7 +17,7 @@ interface ISliderProps {
     gaps: { start: number; end: number }[];
     dataByGapsPositions: { start: number; end: number }[];
     valueToPosition: (value: number) => number;
-    positionToValue: (position: number) => number;
+    positionToValue: (value: number) => number;
   };
   disabled?: boolean;
 }
@@ -49,6 +49,7 @@ export const Slider = ({
       e.preventDefault();
 
       setIsDragging(true);
+      setShowTooltip(true);
 
       const updatePosition = (clientX: number) => {
         if (!sliderRef.current) return;
@@ -69,6 +70,12 @@ export const Slider = ({
   );
 
   useEffect(() => {
+    if (isDragging) {
+      setShowTooltip(true);
+    } else {
+      setShowTooltip(false);
+    }
+
     if (!isDragging) return;
 
     const handleMouseMove = (e: MouseEvent | TouchEvent) => {
@@ -84,6 +91,7 @@ export const Slider = ({
 
     const handleMouseUp = () => {
       setIsDragging(false);
+      setShowTooltip(false);
     };
 
     document.addEventListener("mousemove", handleMouseMove);


### PR DESCRIPTION
Update `src/components/Slider/Slider.tsx` to show the timestamp when the user is dragging the slider.

* Set `showTooltip` to true when `isDragging` is true in the `useEffect` hook.
* Set `showTooltip` to false when `isDragging` is false in the `useEffect` hook.
* Set `showTooltip` to true when the user starts dragging the slider.
* Set `showTooltip` to false when the user stops dragging the slider.
* Remove all comments from the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Adhyyan1252/slider-timestamp/pull/2?shareId=778640a1-2fa6-4231-8160-0dc1c0ddb0fd).
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🕐 Outdated | [`2780c27`](https://github.com/Adhyyan1252/slider-timestamp/pull/2/commits/2780c2715a7a581d8bd911f47fcbe5563628fa9d) (HEAD is `66e2667`) |

> [Run Devin Review](https://staging.itsdev.in/review/Adhyyan1252/slider-timestamp/pull/2?analyze=true)

<a href="https://staging.itsdev.in/review/Adhyyan1252/slider-timestamp/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->